### PR TITLE
Capture error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-
 - If capture fails check for previous capture
+- Remove region code from administrative area
+
+### Added
+- (CYBRSOURCE-32) Allow setting different credentials on Gateway
 
 ## [1.2.0] - 2022-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- If capture fails check for previous capture
+
 ## [1.2.0] - 2022-06-10
 
 ### Added

--- a/dotnet/Controlers/RoutesController.cs
+++ b/dotnet/Controlers/RoutesController.cs
@@ -209,6 +209,21 @@
                                 Value = CybersourceConstants.CaptureSetting.ImmediateCapture
                             }
                         }
+                    },
+                    new CustomField
+                    {
+                        Name = CybersourceConstants.ManifestCustomField.MerchantId,
+                        Type = "text"
+                    },
+                    new CustomField
+                    {
+                        Name = CybersourceConstants.ManifestCustomField.MerchantKey,
+                        Type = "text"
+                    },
+                    new CustomField
+                    {
+                        Name = CybersourceConstants.ManifestCustomField.SharedSecretKey,
+                        Type = "text"
                     }
                 }
             };

--- a/dotnet/Data/CybersourceConstants.cs
+++ b/dotnet/Data/CybersourceConstants.cs
@@ -109,11 +109,14 @@ namespace Cybersource.Data
 
         public static class ManifestCustomField
         {
-            public const string CompanyName = "CompanyName";
-            public const string CompanyTaxId = "CompanyTaxId";
+            public const string CompanyName = "Company Name";
+            public const string CompanyTaxId = "Company Tax Id";
             public const string CaptureSetting = "Capture Setting";
             public const string DelayedCapture = "Delayed Capture";
             public const string ImmediateCapture = "Immediate Capture";
+            public const string MerchantId = "Merchant Id";
+            public const string MerchantKey = "Merchant Key";
+            public const string SharedSecretKey = "Shared Secret Key";
         }
 
         public static class CaptureSetting

--- a/dotnet/Models/CreateSearchRequest.cs
+++ b/dotnet/Models/CreateSearchRequest.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace Cybersource.Models
+{
+    public class CreateSearchRequest
+    {
+        //[JsonProperty("save")]
+        //public string Save { get; set; }
+
+        //[JsonProperty("name")]
+        //public string Name { get; set; }
+
+        //[JsonProperty("timezone")]
+        //public string Timezone { get; set; }
+
+        [JsonProperty("query")]
+        public string Query { get; set; }
+
+        //[JsonProperty("offset")]
+        //public long Offset { get; set; }
+
+        [JsonProperty("limit")]
+        public long Limit { get; set; }
+
+        [JsonProperty("sort")]
+        public string Sort { get; set; }
+    }
+}

--- a/dotnet/Models/SearchResponse.cs
+++ b/dotnet/Models/SearchResponse.cs
@@ -1,0 +1,193 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+
+namespace Cybersource.Models
+{
+    public class SearchResponse
+    {
+        [JsonProperty("_links")]
+        public SearchResponseLinks Links { get; set; }
+
+        [JsonProperty("searchId")]
+        public Guid SearchId { get; set; }
+
+        [JsonProperty("save")]
+        public bool Save { get; set; }
+
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        [JsonProperty("query")]
+        public string Query { get; set; }
+
+        [JsonProperty("count")]
+        public long Count { get; set; }
+
+        [JsonProperty("totalCount")]
+        public long TotalCount { get; set; }
+
+        [JsonProperty("limit")]
+        public long Limit { get; set; }
+
+        [JsonProperty("offset")]
+        public long Offset { get; set; }
+
+        [JsonProperty("sort")]
+        public string Sort { get; set; }
+
+        [JsonProperty("timezone")]
+        public string Timezone { get; set; }
+
+        [JsonProperty("submitTimeUtc")]
+        public DateTimeOffset SubmitTimeUtc { get; set; }
+
+        [JsonProperty("_embedded")]
+        public Embedded Embedded { get; set; }
+    }
+
+    public class Embedded
+    {
+        [JsonProperty("transactionSummaries")]
+        public List<TransactionSummary> TransactionSummaries { get; set; }
+    }
+
+    public class TransactionSummary
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("submitTimeUtc")]
+        public DateTimeOffset SubmitTimeUtc { get; set; }
+
+        [JsonProperty("merchantId")]
+        public string MerchantId { get; set; }
+
+        [JsonProperty("applicationInformation")]
+        public ApplicationInformation ApplicationInformation { get; set; }
+
+        [JsonProperty("buyerInformation")]
+        public BuyerInformation BuyerInformation { get; set; }
+
+        [JsonProperty("clientReferenceInformation")]
+        public ClientReferenceInformation ClientReferenceInformation { get; set; }
+
+        [JsonProperty("consumerAuthenticationInformation")]
+        public ConsumerAuthenticationInformation ConsumerAuthenticationInformation { get; set; }
+
+        [JsonProperty("deviceInformation")]
+        public BuyerInformation DeviceInformation { get; set; }
+
+        [JsonProperty("fraudMarkingInformation")]
+        public BuyerInformation FraudMarkingInformation { get; set; }
+
+        [JsonProperty("merchantInformation")]
+        public BuyerInformation MerchantInformation { get; set; }
+
+        [JsonProperty("orderInformation")]
+        public OrderInformation OrderInformation { get; set; }
+
+        [JsonProperty("paymentInformation")]
+        public PaymentInformation PaymentInformation { get; set; }
+
+        [JsonProperty("processingInformation")]
+        public ProcessingInformation ProcessingInformation { get; set; }
+
+        [JsonProperty("processorInformation")]
+        public ProcessorInformation ProcessorInformation { get; set; }
+
+        [JsonProperty("pointOfSaleInformation")]
+        public PointOfSaleInformation PointOfSaleInformation { get; set; }
+
+        [JsonProperty("riskInformation")]
+        public RiskInformation RiskInformation { get; set; }
+
+        [JsonProperty("_links")]
+        public TransactionSummaryLinks Links { get; set; }
+
+        [JsonProperty("installmentInformation")]
+        public BuyerInformation InstallmentInformation { get; set; }
+    }
+
+    public class TransactionSummaryLinks
+    {
+        [JsonProperty("transactionDetail")]
+        public Self TransactionDetail { get; set; }
+    }
+
+    public class To
+    {
+        [JsonProperty("address1", NullValueHandling = NullValueHandling.Ignore)]
+        public string Address1 { get; set; }
+
+        [JsonProperty("state", NullValueHandling = NullValueHandling.Ignore)]
+        public string State { get; set; }
+
+        [JsonProperty("city", NullValueHandling = NullValueHandling.Ignore)]
+        public string City { get; set; }
+
+        [JsonProperty("country", NullValueHandling = NullValueHandling.Ignore)]
+        public string Country { get; set; }
+
+        [JsonProperty("postalCode", NullValueHandling = NullValueHandling.Ignore)]
+        public string PostalCode { get; set; }
+
+        [JsonProperty("email", NullValueHandling = NullValueHandling.Ignore)]
+        public string Email { get; set; }
+
+        [JsonProperty("phoneNumber", NullValueHandling = NullValueHandling.Ignore)]
+        public string PhoneNumber { get; set; }
+
+        [JsonProperty("firstName", NullValueHandling = NullValueHandling.Ignore)]
+        public string FirstName { get; set; }
+
+        [JsonProperty("lastName", NullValueHandling = NullValueHandling.Ignore)]
+        public string LastName { get; set; }
+    }
+
+    public class Account
+    {
+        [JsonProperty("suffix")]
+        public string Suffix { get; set; }
+    }
+
+    public class Customer
+    {
+        [JsonProperty("customerId", NullValueHandling = NullValueHandling.Ignore)]
+        public string CustomerId { get; set; }
+    }
+
+    public class PaymentType
+    {
+        [JsonProperty("type", NullValueHandling = NullValueHandling.Ignore)]
+        public string Type { get; set; }
+
+        [JsonProperty("method", NullValueHandling = NullValueHandling.Ignore)]
+        public string Method { get; set; }
+    }
+
+    public class AuthorizationOptions
+    {
+        [JsonProperty("authIndicator")]
+        public string AuthIndicator { get; set; }
+    }
+
+    public class Processor
+    {
+        [JsonProperty("name", NullValueHandling = NullValueHandling.Ignore)]
+        public string Name { get; set; }
+    }
+
+    public class Providers
+    {
+        [JsonProperty("fingerPrint")]
+        public BuyerInformation FingerPrint { get; set; }
+    }
+
+    public class SearchResponseLinks
+    {
+        [JsonProperty("self")]
+        public Self Self { get; set; }
+    }
+}
+

--- a/dotnet/Services/CybersourceApi.cs
+++ b/dotnet/Services/CybersourceApi.cs
@@ -410,13 +410,14 @@ namespace Cybersource.Services
             
             if (response != null)
             {
+                //Console.WriteLine($"ProcessPayment [{response.StatusCode}] {response.Message}");
                 if (response.Success)
                 {
                     paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
                 }
                 else
                 {
-                    _context.Vtex.Logger.Error("ProcessPayment", null, $"[{response.StatusCode}] {response.Message}");
+                    _context.Vtex.Logger.Error("ProcessPayment", null, $"[{response.StatusCode}] {response.Message}", null, new[] { ("Request", JsonConvert.SerializeObject(payments)) });
                 }
             }
             else
@@ -425,7 +426,7 @@ namespace Cybersource.Services
             }
 
             //_context.Vtex.Logger.Debug("ProcessPayment", "ProcessPayment", "ProcessPayment", new [] { ("Request", JsonConvert.SerializeObject(payments)), ("Response", JsonConvert.SerializeObject(paymentsResponse)) });
-            _context.Vtex.Logger.Debug("ProcessPayment", "ProcessPayment", "ProcessPayment", new[] { ("Request", JsonConvert.SerializeObject(payments)) });
+            //_context.Vtex.Logger.Debug("ProcessPayment", "ProcessPayment", "ProcessPayment", new[] { ("Request", JsonConvert.SerializeObject(payments)) });
 
             return paymentsResponse;
         }
@@ -693,13 +694,20 @@ namespace Cybersource.Services
                 }
             };
 
-            string json = JsonConvert.SerializeObject(cybersourceBinLookupRequest);
-            string endpoint = $"{CybersourceConstants.BIN}binlookup";
-            SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
-            _context.Vtex.Logger.Debug("BinLookup", null, null, new[] { ("Bin", cardNumber), ("request", json), ("response", JsonConvert.SerializeObject(response)) });
-            if (response != null)
+            try
             {
-                cybersourceBinLookupResponse = JsonConvert.DeserializeObject<CybersourceBinLookupResponse>(response.Message);
+                string json = JsonConvert.SerializeObject(cybersourceBinLookupRequest);
+                string endpoint = $"{CybersourceConstants.BIN}binlookup";
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                _context.Vtex.Logger.Debug("BinLookup", null, null, new[] { ("Bin", cardNumber), ("request", json), ("response", JsonConvert.SerializeObject(response)) });
+                if (response != null)
+                {
+                    cybersourceBinLookupResponse = JsonConvert.DeserializeObject<CybersourceBinLookupResponse>(response.Message);
+                }
+            }
+            catch (Exception ex)
+            {
+                _context.Vtex.Logger.Error("BinLookup", null, "Error", ex, new[] { ("Bin", cardNumber) });
             }
 
             return cybersourceBinLookupResponse;

--- a/dotnet/Services/CybersourceApi.cs
+++ b/dotnet/Services/CybersourceApi.cs
@@ -663,6 +663,20 @@ namespace Cybersource.Services
 
             return retrieveTransaction;
         }
+
+        public async Task<SearchResponse> CreateSearchRequest(CreateSearchRequest createSearchRequest)
+        {
+            SearchResponse searchResponse = null;
+            string json = JsonConvert.SerializeObject(createSearchRequest);
+            string endpoint = $"{CybersourceConstants.TRANSACTIONS}searches";
+            SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+            if (response != null)
+            {
+                searchResponse = JsonConvert.DeserializeObject<SearchResponse>(response.Message);
+            }
+
+            return searchResponse;
+        }
         #endregion Reporting
 
         public async Task<CybersourceBinLookupResponse> BinLookup(string cardNumber)

--- a/dotnet/Services/ICybersourceApi.cs
+++ b/dotnet/Services/ICybersourceApi.cs
@@ -21,6 +21,7 @@ namespace Cybersource.Services
         Task<string> RetrieveAvailableReports(DateTime dtStartTime, DateTime dtEndTime);
         Task<string> GetPurchaseAndRefundDetails(DateTime dtStartTime, DateTime dtEndTime);
         Task<RetrieveTransaction> RetrieveTransaction(string transactionId);
+        Task<SearchResponse> CreateSearchRequest(CreateSearchRequest createSearchRequest);
 
         Task<CybersourceBinLookupResponse> BinLookup(string cardNumber);
     }

--- a/paymentProvider/configuration.json
+++ b/paymentProvider/configuration.json
@@ -55,6 +55,18 @@
       ],
       "name": "Capture Setting",
       "type": "select"
+    },
+    {
+      "name": "Merchant Id",
+      "type": "text"
+    },
+    {
+      "name": "Merchant Key",
+      "type": "text"
+    },
+    {
+      "name": "Shared Secret Key",
+      "type": "text"
     }
   ]
 }


### PR DESCRIPTION
### Fixed
- If capture fails check for previous capture by loading transaction history from Cybersource
- (CYBRSOURCE-33) Remove region code from administrative area.  This is for states in Chile that have a format like `REGIÓN DEL BIOBÍO (VIII)`.  The code `(VIII)' must be removed and only `REGIÓN DEL BIOBÍO' sent to Cybersource

### Added
- (CYBRSOURCE-32) Allow setting different credentials on Gateway.  Credentials set on the Gateway page will override admin page credentials.
