### PR TITLE
(CYBRSOURCE-33) Convert Chile region name to iso code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- (CYBRSOURCE-33) Convert Chile region name to iso code
+
 ## [1.3.0] - 2022-06-15
 
 ### Fixed

--- a/dotnet/Data/CybersourceConstants.cs
+++ b/dotnet/Data/CybersourceConstants.cs
@@ -306,5 +306,41 @@ namespace Cybersource.Data
            { "ZAF", "ZA" },    // South Africa
            { "ZWE", "ZW" },    // Zimbabwe
         };
+
+        //Aisén del General Carlos Ibáñez del Campo   CL.AI   AI  CI02    XI  94,271  108,494 41,890  Coihaique
+        //Antofagasta CL.AN                 AN  CI03    II  530,879 126,049 48,668  Antofagasta
+        //Araucanía   CL.AR                 AR  CI04    IX  889,492 31,842  12,294  Temuco
+        //Arica and Parinacota    CL.AP     AP  CI16    XV  212,813 16,873  6,515   Arica
+        //Atacama CL.AT                     AT  CI05    III 284,992 75,176  29,026  Copiapó
+        //Bío-Bío CL.BI                     BI  CI06    VIII    1,950,482   37,069  14,312  Concepción
+        //Coquimbo    CL.CO                 CO  CI07    IV  687,806 40,580  15,668  La Serena
+        //Libertador General Bernardo O'Higgins	CL.LI	LI	CI08	VI	851,406	16,387	6,327	Rancagua
+        //Los Lagos   CL.LG                 LL  CI14    X   767,714 48,584  18,758  Puerto Montt
+        //Los Ríos    CL.LR                 LR  CI17    XIV 364,183 18,430  7,116   Valdivia
+        //Magallanes y Antártica Chilena  CL.MA   MA  CI10    XII 155,332 132,291 51,078  Punta Arenas
+        //Maule   CL.ML                     ML  CI11    VII 955,048 30,296  11,697  Talca
+        //Ñuble   CL.NB           XVI 480,609 13,178  5,088   Chillán
+        //Región Metropolitana de Santiago    CL.RM   RM  CI12        6,604,835   15,403  5,947   Santiago
+        //Tarapacá    CL.TP                 TA  CI15    I   295,095 42,226  16,303  Iquique
+        //Valparaíso  CL.VS                 VS  CI01    V   1,697,581   16,396  6,331   Valparaíso
+        internal static readonly Dictionary<string, string> AdministrativeAreasChile = new Dictionary<string, string>()
+        {
+           { "Región Metropolitana", "RM" },
+           { "Región de Arica y Parinacota (XV)", "AP" },
+           { "Región de Tarapacá (I)", "TA" },
+           { "Región de Antofagasta (II)", "AN" },
+           { "Región de Atacama (III)", "AT" },
+           { "Región de Coquimbo (IV)", "CO" },
+           { "Región de Valparaíso (V)", "VS" },
+           { "Región del Libertador General Bernardo O’Higgins (VI)", "LI" },
+           { "Región del Maule (VII)", "ML" },
+           { "Región del Ñuble (XVI)", "Ñuble" },
+           { "Región del Biobío (VIII)", "BI" },
+           { "Región de La Araucanía (IX)", "AR" },
+           { "Región de Los Ríos (XIV)", "LR" },
+           { "Región de Los Lagos (X)", "LL" },
+           { "Región de Aysén del General Carlos Ibáñez del Campo (XI)", "AI" },
+           { "Región de Magallanes y la Antártica Chilena (XII)", "MA" },
+        };
     }
 }


### PR DESCRIPTION
The region names passed in the payment request must be converted to a two digit iso code.
Various methods to normalize the encoding of the names was attempted, but was unreliable, so matching is done on the region number.