### PR TITLE
[CYBERSOURCE-39] Set locality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- If city is null, use neighborhood value for locality
+
 ## [1.3.2] - 2022-07-11
 
 ### Changed

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -162,7 +162,7 @@ namespace Cybersource.Services
                         lastName = createPaymentRequest.MiniCart.Buyer.LastName,
                         address1 = $"{createPaymentRequest.MiniCart.BillingAddress.Number} {createPaymentRequest.MiniCart.BillingAddress.Street}",
                         address2 = createPaymentRequest.MiniCart.BillingAddress.Complement,
-                        locality = createPaymentRequest.MiniCart.BillingAddress.City,
+                        locality = createPaymentRequest.MiniCart.BillingAddress.City ?? createPaymentRequest.MiniCart.BillingAddress.Neighborhood,
                         administrativeArea = GetAdministrativeArea(createPaymentRequest.MiniCart.BillingAddress.State, this.GetCountryCode(createPaymentRequest.MiniCart.BillingAddress.Country)),
                         postalCode = createPaymentRequest.MiniCart.BillingAddress.PostalCode,
                         country = this.GetCountryCode(createPaymentRequest.MiniCart.BillingAddress.Country),
@@ -176,7 +176,7 @@ namespace Cybersource.Services
                         administrativeArea = GetAdministrativeArea(createPaymentRequest.MiniCart.ShippingAddress.State, this.GetCountryCode(createPaymentRequest.MiniCart.ShippingAddress.Country)),
                         country = this.GetCountryCode(createPaymentRequest.MiniCart.ShippingAddress.Country),
                         postalCode = createPaymentRequest.MiniCart.ShippingAddress.PostalCode,
-                        locality = createPaymentRequest.MiniCart.ShippingAddress.City,
+                        locality = createPaymentRequest.MiniCart.ShippingAddress.City ?? createPaymentRequest.MiniCart.ShippingAddress.Neighborhood,
                         phoneNumber = createPaymentRequest.MiniCart.Buyer.Phone, // Note that this is the buyer's number, we do not have a number for the shipping destination
                         firstName = createPaymentRequest.MiniCart.Buyer.FirstName, // defaulting to buyer info.  This should be ovverridden from the order data
                         lastName = createPaymentRequest.MiniCart.Buyer.LastName,
@@ -265,13 +265,13 @@ namespace Cybersource.Services
                     {
                         if (CybersourceConstants.CardType.Unknown.Equals(CybersourceConstants.CardType.Visa) || CybersourceConstants.CardType.Unknown.Equals(CybersourceConstants.CardType.MasterCard))
                         {
-                            plan = "0";  // 0: no deferred payment, 1: 30 días, 2: 60 días, 3: 90 días
+                            plan = "0";  // 0: no deferred payment, 1: 30 dï¿½as, 2: 60 dï¿½as, 3: 90 dï¿½as
                             payment.issuerInformation = new IssuerInformation
                             {
                                 //POS 1 - 6:014001
                                 //POS 7 - 8: # of installments
                                 //POS 9 - 16:00000000
-                                //POS 17: plan(0: no deferred payment, 1: 30 días, 2: 60 días, 3: 90 días)
+                                //POS 17: plan(0: no deferred payment, 1: 30 dï¿½as, 2: 60 dï¿½as, 3: 90 dï¿½as)
                                 discretionaryData = $"14001{numberOfInstallments}00000000{plan}"
                             };
                         }
@@ -813,7 +813,7 @@ namespace Cybersource.Services
                             lastName = sendAntifraudDataRequest.MiniCart.Buyer.LastName,
                             address1 = $"{sendAntifraudDataRequest.MiniCart.Buyer.Address.Number} {sendAntifraudDataRequest.MiniCart.Buyer.Address.Street}",
                             address2 = sendAntifraudDataRequest.MiniCart.Buyer.Address.Complement,
-                            locality = sendAntifraudDataRequest.MiniCart.Buyer.Address.City,
+                            locality = sendAntifraudDataRequest.MiniCart.Buyer.Address.City ?? sendAntifraudDataRequest.MiniCart.Buyer.Address.Neighborhood,
                             administrativeArea = sendAntifraudDataRequest.MiniCart.Buyer.Address.State,
                             postalCode = sendAntifraudDataRequest.MiniCart.Buyer.Address.PostalCode,
                             country = this.GetCountryCode(sendAntifraudDataRequest.MiniCart.Buyer.Address.Country),
@@ -1109,7 +1109,7 @@ namespace Cybersource.Services
 
         public string GetAdministrativeAreaChile(string region)
         {
-            string regionCode = "RM"; // Default to Región Metropolitana
+            string regionCode = "RM"; // Default to Regiï¿½n Metropolitana
             if (region.Contains("(") && region.Contains(")"))
             {
                 string regionumber = region.Split('(', ')')[1];
@@ -1119,50 +1119,50 @@ namespace Cybersource.Services
                     case "I": // Region de Tarapaca
                         regionCode = "TA";
                         break;
-                    case "II": // Región de Antofagasta
+                    case "II": // Regiï¿½n de Antofagasta
                         regionCode = "AN";
                         break;
-                    case "III": // Región de Atacama
+                    case "III": // Regiï¿½n de Atacama
                         regionCode = "AT";
                         break;
-                    case "IV": // Región de Coquimbo
+                    case "IV": // Regiï¿½n de Coquimbo
                         regionCode = "CO";
                         break;
-                    case "V": // Región de Valparaíso
+                    case "V": // Regiï¿½n de Valparaï¿½so
                         regionCode = "VS";
                         break;
-                    case "VI": // Región del Libertador General Bernardo O’Higgins
+                    case "VI": // Regiï¿½n del Libertador General Bernardo Oï¿½Higgins
                         regionCode = "LI";
                         break;
-                    case "VII": // Región del Maule
+                    case "VII": // Regiï¿½n del Maule
                         regionCode = "ML";
                         break;
-                    case "VIII": // Región del Biobío
+                    case "VIII": // Regiï¿½n del Biobï¿½o
                         regionCode = "BI";
                         break;
-                    case "IX": // Región de La Araucanía
+                    case "IX": // Regiï¿½n de La Araucanï¿½a
                         regionCode = "AR";
                         break;
-                    case "X": // Región de Los Lagos
+                    case "X": // Regiï¿½n de Los Lagos
                         regionCode = "LL";
                         break;
                     case "XI": // Region de Aysen del General Carlos Ibanez del Campo
                         regionCode = "AI";
                         break;
-                    case "XII": // Región de Magallanes y la Antártica Chilena
+                    case "XII": // Regiï¿½n de Magallanes y la Antï¿½rtica Chilena
                         regionCode = "MA";
                         break;
                     case "":
-                    case "XIII": // Región Metropolitana de Santiago
+                    case "XIII": // Regiï¿½n Metropolitana de Santiago
                         regionCode = "RM";
                         break;
-                    case "XIV": // Región de Los Ríos
+                    case "XIV": // Regiï¿½n de Los Rï¿½os
                         regionCode = "LR";
                         break;
                     case "XV": // Region de Arica y Parinacota
                         regionCode = "AP";
                         break;
-                    case "XVI": // Región del Ñuble
+                    case "XVI": // Regiï¿½n del ï¿½uble
                         regionCode = region;
                         break;
                     default:


### PR DESCRIPTION
Previously, the city field for Chile is hidden. So that he city value is null, and cybersource don't like it so the payment could not process.

This PR set the locality equal to Neighborhood if the City is null