### PR TITLE
Added custom parser for Panama region codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
-
-- Cypress tests changed to use new orderForm lock tool
+### Added
+- Added custom parser for Panama region codes
 
 ## [1.6.2] - 2022-10-06
 

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -1879,6 +1879,20 @@ namespace Cybersource.Services
         public string GetAdministrativeAreaPanama(string region)
         {
             string regionCode = string.Empty;
+            if(region.Contains('-'))
+            {
+                string regionCodeTemp = region.Split('-').Last();
+                if(!string.IsNullOrEmpty(regionCodeTemp))
+                {
+                    int regionCodeParsed = 0;
+                    bool isNumeric = int.TryParse(regionCodeTemp, out regionCodeParsed);
+                    if(isNumeric && regionCodeParsed > 0 && regionCodeParsed < 13)
+                    {
+                        return regionCodeTemp;
+                    }
+                }
+            }
+
             switch (region.ToLowerInvariant())
             {
                 case "bocas del toro":


### PR DESCRIPTION
In the first column, the frontend name that customers will see in the checkout
in the second column the ISO code that must be sent to Cybersource
in the third column, the value that will be saved in the order and the connector should “read” to decode the iso code.
![image](https://user-images.githubusercontent.com/47258865/194551888-d19f692d-8ca3-40e6-a234-7cc854d8112d.png)
