### PR TITLE
CYBRSOURCE-55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- (CYBRSOURCE-55) Ecuador payload customizations: add shipping tax as a line item
+
 ## [1.8.0] - 2022-10-20
 
 ### Added

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -634,25 +634,6 @@ namespace Cybersource.Services
 
                 try
                 {
-                    // Add shipping tax as a line item
-                    LineItem lineItem = new LineItem
-                    {
-                        productName = "ADMINISTRACION MANEJO DE PRODUCTO",
-                        unitPrice = createPaymentRequest.MiniCart.ShippingValue.ToString(), // Shipping cost without taxes
-                        quantity = "1",
-                        taxAmount = createPaymentRequest.MiniCart.ShippingValue.ToString(), // unitPrice * quantity
-                        taxDetails = new TaxDetail[]
-                        {
-                            new TaxDetail
-                            {
-                                type = "national",
-                                amount = ((decimal)shippingTax / 100).ToString() // taxAmount * taxRate (based on configuration in the account)
-                }
-                        }
-                    };
-
-                    payment.orderInformation.lineItems.Add(lineItem);
-
                     if (merchantSettings.Region != null && merchantSettings.Region.Equals(CybersourceConstants.Regions.Ecuador))
                     {
                         payment.orderInformation.amountDetails.nationalTaxIncluded = createPaymentRequest.MiniCart.TaxValue > 0m ? "1" : "0";
@@ -661,6 +642,25 @@ namespace Cybersource.Services
                             purchaseOrderNumber = createPaymentRequest.OrderId,
                             taxable = createPaymentRequest.MiniCart.TaxValue > 0m
                         };
+
+                        // Add shipping tax as a line item
+                        LineItem lineItem = new LineItem
+                        {
+                            productName = "ADMINISTRACION MANEJO DE PRODUCTO",
+                            unitPrice = createPaymentRequest.MiniCart.ShippingValue.ToString(), // Shipping cost without taxes
+                            quantity = "1",
+                            taxAmount = createPaymentRequest.MiniCart.ShippingValue.ToString(), // unitPrice * quantity
+                            taxDetails = new TaxDetail[]
+                            {
+                                new TaxDetail
+                                {
+                                    type = "national",
+                                    amount = ((decimal)shippingTax / 100).ToString() // taxAmount * taxRate (based on configuration in the account)
+                                }
+                            }
+                        };
+
+                        payment.orderInformation.lineItems.Add(lineItem);
                     }
                 }
                 catch(Exception ex)

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -554,7 +554,7 @@ namespace Cybersource.Services
                     }
                 }
 
-                long shippingTax = 0;
+                decimal taxRate = 0;
                 foreach (VtexItem vtexItem in createPaymentRequest.MiniCart.Items)
                 {
                     string taxAmount = string.Empty;
@@ -572,11 +572,7 @@ namespace Cybersource.Services
                                 {
                                     if (priceTag.IsPercentual ?? false)
                                     {
-                                        shippingTax += (long)Math.Round(vtexOrderItem.SellingPrice * priceTag.RawValue, MidpointRounding.AwayFromZero);
-                                    }
-                                    else
-                                    {
-                                        shippingTax += priceTag.Value / vtexOrderItem.Quantity;
+                                        taxRate = (decimal)priceTag.RawValue;
                                     }
                                 }
                                 else
@@ -655,7 +651,7 @@ namespace Cybersource.Services
                                 new TaxDetail
                                 {
                                     type = "national",
-                                    amount = ((decimal)shippingTax / 100).ToString() // taxAmount * taxRate (based on configuration in the account)
+                                    amount = (createPaymentRequest.MiniCart.ShippingValue * taxRate).ToString() // taxAmount * taxRate (based on configuration in the account)
                                 }
                             }
                         };

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -555,6 +555,8 @@ namespace Cybersource.Services
                 }
 
                 decimal taxRate = 0;
+                bool useRate = false;
+                double shippingTaxAmount = 0;
                 foreach (VtexItem vtexItem in createPaymentRequest.MiniCart.Items)
                 {
                     string taxAmount = string.Empty;
@@ -573,6 +575,11 @@ namespace Cybersource.Services
                                     if (priceTag.IsPercentual ?? false)
                                     {
                                         taxRate = (decimal)priceTag.RawValue;
+                                        useRate = true;
+                                    }
+                                    else
+                                    {
+                                        shippingTaxAmount += priceTag.RawValue;
                                     }
                                 }
                                 else
@@ -651,7 +658,7 @@ namespace Cybersource.Services
                                 new TaxDetail
                                 {
                                     type = "national",
-                                    amount = (createPaymentRequest.MiniCart.ShippingValue * taxRate).ToString() // taxAmount * taxRate (based on configuration in the account)
+                                    amount = useRate ? (createPaymentRequest.MiniCart.ShippingValue * taxRate).ToString() : shippingTaxAmount.ToString()   // taxAmount * taxRate (based on configuration in the account)
                                 }
                             }
                         };


### PR DESCRIPTION
Ecuador payload customizations: add shipping tax as a line item in the format:
{
    "productName": "ADMINISTRACION MANEJO DE PRODUCTO", //same name always
    "productSKU": "", //not required by CS, can be omitted (preferable) or empty
    "quantity": "1", //always 1
    "unitPrice": "25.00", // Shipping cost without taxes
    "taxAmount": "25.00", // unitPrice * quantity
     "taxDetails": [
      {
        "type": "national",
        "amount": "3.00"  // taxAmount * taxRate (based on configuration in the account)
      }
    ]
  }  
