### PR TITLE
Fix/tax details amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Changed order of operations when calculating tax detail amount
+
 ## [1.8.3] - 2022-11-10
 
 ### Added

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -622,7 +622,7 @@ namespace Cybersource.Services
                                 new TaxDetail
                                 {
                                     type = "national",
-                                    amount = (((decimal)itemTax / 100) * vtexItem.Quantity).ToString()
+                                    amount = ((itemTax * vtexItem.Quantity) / 100).ToString()
                                 }
                             };
                         }


### PR DESCRIPTION
Changed order of operations when calculating tax detail amount to reduce rounding errors.
Error:
The taxDetails.amount was sent as 5.19 , however the correct value is 5.20
The "discrepancy" is an accuracy problem due to the way the calculation is done:
taxDetail.amount = (unitPrice * taxRate) * quantity
14.45 * 0.12 = 1.734 ≃ 1.73 (note rounded value)
1.73 * 3 = 5.19 (value not accurate)
The solution:
In order to avoid this problem, the math must be done differently
taxDetail.amount = (unitPrice * quantity) * taxRate
14.45 * 3 =  43.35 (note no rounding needed)
43.35 * 0.12 = 5.202 ≃ 5.20 (note rounded value)
Please note taxRate is defined in the VTEX account (12% in this case)