### PR TITLE
Decimal places to two digits for EC tax fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Decimal places to two digits for EC tax fields
+
 ## [1.8.5] - 2022-11-22
 
 ### Changed

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -624,7 +624,7 @@ namespace Cybersource.Services
                                 new TaxDetail
                                 {
                                     type = "national",
-                                    amount = ((itemTax * vtexItem.Quantity) / 100).ToString()
+                                    amount = ((itemTax * vtexItem.Quantity) / 100m).ToString()
                                 }
                             };
                         }
@@ -660,11 +660,11 @@ namespace Cybersource.Services
                                 new TaxDetail
                                 {
                                     type = "national",
-                                    amount = useRate ? (createPaymentRequest.MiniCart.ShippingValue * taxRate).ToString() : shippingTaxAmount.ToString()   // taxAmount * taxRate (based on configuration in the account)
+                                    amount = useRate ? (createPaymentRequest.MiniCart.ShippingValue * taxRate).ToString("0.00") : shippingTaxAmount.ToString("0.00")   // taxAmount * taxRate (based on configuration in the account)
                                 }
                             }
                         };
-
+                        
                         payment.orderInformation.lineItems.Add(lineItem);
                     }
                 }


### PR DESCRIPTION
Problem:
The tax calculation for products is not reporting any decimal. It seems that the number is trimming the decimal segment.
For the shipping taxes item, it is showing three decimal positions instead of two.

sandboxusdev master is pointed to cybersource workspace for testing