### PR TITLE
Do not set administrativeArea

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Do not set administrativeArea for Bolivia, Guatemala, Puerto Rico and the Dominican Republic
+
 ## [1.11.0] - 2023-01-06
 
 ### Added

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -1718,6 +1718,12 @@ namespace Cybersource.Services
                         case "PA": // Panama
                             regionCode = GetAdministrativeAreaPanama(region);
                             break;
+                        case "BO": // Bolivia
+                        case "GT": // Guatemala
+                        case "PR": // Puerto Rico
+                        case "DO": // Dominican Republic
+                            regionCode = null;
+                            break;
                     }
                 }
             }


### PR DESCRIPTION
Request:
The client is trying to launch their stores in Bolivia, Guatemala, Puerto Rico and the Dominican Republic.
They have identified the following gap:
In the shipto_state (orderInformation.shipTo.administrativeArea) and billto_state (orderInformation.billTo.administrativeArea) attributes, values ​​with the potential to generate errors in transaction processing are being sent (eg they contain tildes).
Cybersource's recommendation is that these attributes are not sent as they are optional for these countries, so it would be necessary to exclude them from the payment payload.