### PR TITLE
Do not set administrativeArea for Costa Rica and El Salvador

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Do not set administrativeArea for Costa Rica and El Salvador
+
 ## [1.13.0] - 2023-01-10
 
 ### Changed

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -1722,6 +1722,8 @@ namespace Cybersource.Services
                         case "GT": // Guatemala
                         case "PR": // Puerto Rico
                         case "DO": // Dominican Republic
+                        case "CR": // Costa Rica
+                        case "SV": // El Salvador
                             regionCode = null;
                             break;
                     }


### PR DESCRIPTION
Add Costa Rica and El Salvador to the list of countries that do not set an administrative area