### PR TITLE
Bug/empty auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Empty authorization id on capture
+
 ## [1.13.0] - 2023-01-10
 
 ### Changed

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -941,7 +941,7 @@ namespace Cybersource.Services
                 };
 
                 string authId = capturePaymentRequest.AuthorizationId;
-                if (paymentData != null)
+                if (paymentData != null && !string.IsNullOrEmpty(paymentData.AuthorizationId))
                 {
                     authId = paymentData.AuthorizationId;
                 }


### PR DESCRIPTION
When payment auth is enabled and the card is authorized without a challenge, the auth id is not recorded in the payment data and the value passed in the request should be used.