### PR TITLE
Changes for tafmx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Removed threeDSServerTransactionId & acsTransactionId from Payer Auth requests
+- Removed referenceDataNumber from Item
+- For Banorte, installmentPlan Type is 2 for AMEX, 1 for everything else
+
 ## [1.13.4] - 2023-01-19
 
 ### Fixed

--- a/dotnet/Models/LineItem.cs
+++ b/dotnet/Models/LineItem.cs
@@ -30,7 +30,7 @@ namespace Cybersource.Models
         public string weightIdentifier { get; set; }
         public string weightUnit { get; set; }
         public string referenceDataCode { get; set; }
-        public string referenceDataNumber { get; set; }
+        //public string referenceDataNumber { get; set; }
         public string productDescription { get; set; }
         public string giftCardCurrency { get; set; }
         public string shippingDestinationTypes { get; set; }

--- a/dotnet/Models/RetrieveTransaction.cs
+++ b/dotnet/Models/RetrieveTransaction.cs
@@ -322,14 +322,14 @@ namespace Cybersource.Models
         [JsonProperty("directoryServerTransactionId")]
         public string DirectoryServerTransactionId { get; set; }
 
-        [JsonProperty("threeDSServerTransactionId")]
-        public Guid ThreeDsServerTransactionId { get; set; }
+        //[JsonProperty("threeDSServerTransactionId")]
+        //public Guid ThreeDsServerTransactionId { get; set; }
 
         [JsonProperty("acsOperatorID")]
         public string AcsOperatorId { get; set; }
 
-        [JsonProperty("acsTransactionId")]
-        public Guid AcsTransactionId { get; set; }
+        //[JsonProperty("acsTransactionId")]
+        //public Guid AcsTransactionId { get; set; }
     }
 
     public partial class StrongAuthentication

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -316,7 +316,7 @@ namespace Cybersource.Services
                             payment.installmentInformation = new InstallmentInformation
                             {
                                 totalCount = numberOfInstallments,
-                                planType = "02"
+                                planType = cardBrandName.Equals(CybersourceConstants.CardType.AmericanExpress) ? "02" : "01"
                             };
                         }
                         else


### PR DESCRIPTION
Removed threeDSServerTransactionId & acsTransactionId from Payer Auth requests
Removed referenceDataNumber from Item
For Banorte, installmentPlan Type is 2 for AMEX, 1 for everything else

https://cybersource--sandboxusdev.myvtex.com/