### PR TITLE
Add Order Suffix when searching Cybersource transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Add optional Order Suffix to refernce number when searching Cyberouse transactions
+
 ### Changed
 - [ENGINEERS-1109] - Fix payer auth refund tests
 

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -1077,7 +1077,7 @@ namespace Cybersource.Services
                     else
                     {
                         // Try to get transaction from Cybersource
-                        SearchResponse searchResponse = await this.SearchTransaction(referenceNumber);
+                        SearchResponse searchResponse = await this.SearchTransaction($"{referenceNumber}{orderSuffix}");
                         if (searchResponse != null)
                         {
                             foreach (var transactionSummary in searchResponse.Embedded.TransactionSummaries.Where(transactionSummary => transactionSummary.ApplicationInformation.Applications.Any(ai => ai.Name.Equals(CybersourceConstants.Applications.Capture) && ai.ReasonCode.Equals("100"))))
@@ -2761,7 +2761,14 @@ namespace Cybersource.Services
                         case "ERROR":
                             string referenceNumber = await _vtexApiService.GetOrderId(createPaymentRequest.Reference, createPaymentRequest.OrderId);
                             await Task.Delay(6000); // wait for transaction to be available
-                            SearchResponse searchResponse = await this.SearchTransaction(referenceNumber);
+                            string orderSuffix = string.Empty;
+                            MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
+                            if (!string.IsNullOrEmpty(merchantSettings.OrderSuffix))
+                            {
+                                orderSuffix = merchantSettings.OrderSuffix.Trim();
+                            }
+
+                            SearchResponse searchResponse = await this.SearchTransaction($"{referenceNumber}{orderSuffix}");
                             if (searchResponse != null)
                             {
                                 _context.Vtex.Logger.Warn("GetPaymentStatus", null, "Loaded Transactions from Cybersource", new[] { ("searchResponse", JsonConvert.SerializeObject(searchResponse)) });


### PR DESCRIPTION
Add optional Order Suffix to reference number when searching Cybersource transactions.
When a capture attempt returns an error, Cybersource is searched using the reference number.  If there is an optional suffix set, it must be added to the reference.