### PR TITLE
If Decision Manager is not being used, mark pending auths as approved.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- If Decision Manager is not being used, mark pending auths as approved.
+
 ## [1.14.0] - 2023-03-16
 
 ### Added

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -2720,8 +2720,6 @@ namespace Cybersource.Services
 
                             break;
                         case "AUTHORIZED_PENDING_REVIEW":
-                        case "PENDING_AUTHENTICATION":
-                        case "PENDING_REVIEW":
                             paymentStatus = CybersourceConstants.VtexAuthStatus.Undefined;
                             createPaymentResponse.DelayToCancel = 5 * 60 * 60 * 24;
                             bool isDecisionManagerInUse = true;
@@ -2751,6 +2749,8 @@ namespace Cybersource.Services
                             }
 
                             break;
+                        case "PENDING_AUTHENTICATION":
+                        case "PENDING_REVIEW":
                         case "INVALID_REQUEST":
                             paymentStatus = CybersourceConstants.VtexAuthStatus.Undefined;
                             createPaymentResponse.DelayToCancel = 5 * 60 * 60 * 24;

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -2735,7 +2735,7 @@ namespace Cybersource.Services
                             }
                             catch (Exception ex)
                             {
-                                paymentStatus = CybersourceConstants.VtexAuthStatus.Denied; // jic
+                                paymentStatus = CybersourceConstants.VtexAuthStatus.Approved; // jic
                                 _context.Vtex.Logger.Error("GetPaymentStatus", "Decision Manager Active Setting",
                                 "Error: ", ex,
                                 new[]
@@ -2746,8 +2746,8 @@ namespace Cybersource.Services
 
                             if(!isDecisionManagerInUse)
                             {
-                                // If Decision Manager is not used, mark Pending as Denied
-                                paymentStatus = CybersourceConstants.VtexAuthStatus.Denied;
+                                // If Decision Manager is not used, mark Pending as Approved
+                                paymentStatus = CybersourceConstants.VtexAuthStatus.Approved;
                             }
 
                             break;


### PR DESCRIPTION
If not using DM, accept Authorized Pending orders.  Final status will be handled by antifraud provider.