### PR TITLE
Added Timeout to Create Payment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added Timeout to Create Payment
+- If Auth&Bill attempt times out, check transactions in Cybersource before another attempt
+
 ## [1.16.1] - 2023-05-04
 
 ### Fixed

--- a/dotnet/Models/PaymentData.cs
+++ b/dotnet/Models/PaymentData.cs
@@ -15,5 +15,6 @@ namespace Cybersource.Models
         public string AuthenticationTransactionId { get; set; }
         public ConsumerAuthenticationInformation ConsumerAuthenticationInformation { get; set; }
         public string OrderId { get; set; }
+        public bool TimedOut { get; set; }
     }
 }


### PR DESCRIPTION
CreatePayment requests will time out after 25 seconds. (Payments times out after ~30s)
If Auth&Bill attempt times out, check transactions in Cybersource before another attempt