### PR TITLE
Fix for account override settings not being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fix for account override settings not being used
+
 ## [1.18.0] - 2023-05-22
 
 ### Changed

--- a/dotnet/Controlers/RoutesController.cs
+++ b/dotnet/Controlers/RoutesController.cs
@@ -40,7 +40,6 @@
         public async Task<IActionResult> CreatePayment()
         {
             CreatePaymentResponse createPaymentResponse = null;
-            PaymentsResponse paymentsResponse = null;
             if ("post".Equals(HttpContext.Request.Method, StringComparison.OrdinalIgnoreCase))
             {
                 string bodyAsText = await new StreamReader(HttpContext.Request.Body).ReadToEndAsync();

--- a/dotnet/Services/CybersourceApi.cs
+++ b/dotnet/Services/CybersourceApi.cs
@@ -776,7 +776,7 @@ namespace Cybersource.Services
 
             try
             {
-                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings(); // TODO: Get override settings
+                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
                 string organizationId = merchantSettings.MerchantId;
                 string endpoint = $"{CybersourceConstants.REPORTING}conversion-details?startTime={startTime}&endTime={endTime}&organizationId={organizationId}&";
                 SendResponse response = await this.SendReportRequest(HttpMethod.Get, endpoint, null, merchantSettings);
@@ -855,7 +855,7 @@ namespace Cybersource.Services
 
             try
             {
-                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings(); // TODO: Get override settings
+                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
                 string organizationId = merchantSettings.MerchantId;
                 string endpoint = $"{CybersourceConstants.REPORTING}report-downloads?reportDate={reportDate}&organizationId={organizationId}&reportName={reportName}";
                 SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null, merchantSettings);

--- a/dotnet/Services/CybersourceApi.cs
+++ b/dotnet/Services/CybersourceApi.cs
@@ -42,13 +42,12 @@ namespace Cybersource.Services
                 $"{this._environmentVariableProvider.ApplicationVendor}.{this._environmentVariableProvider.ApplicationName}";
         }
 
-        public async Task<SendResponse> SendRequest(HttpMethod method, string endpoint, string jsonSerializedData)
+        public async Task<SendResponse> SendRequest(HttpMethod method, string endpoint, string jsonSerializedData, MerchantSettings merchantSettings)
         {
             SendResponse sendResponse = null;
 
             try
             {
-                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
                 string urlBase = CybersourceConstants.ProductionApiEndpoint;
                 if (!merchantSettings.IsLive)
                 {
@@ -117,13 +116,12 @@ namespace Cybersource.Services
             return sendResponse;
         }
 
-        public async Task<SendResponse> SendReportRequest(HttpMethod method, string endpoint, string jsonSerializedData)
+        public async Task<SendResponse> SendReportRequest(HttpMethod method, string endpoint, string jsonSerializedData, MerchantSettings merchantSettings)
         {
             SendResponse sendResponse = null;
 
             try
             {
-                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
                 string urlBase = CybersourceConstants.ProductionApiEndpoint;
                 if (!merchantSettings.IsLive)
                 {
@@ -179,13 +177,12 @@ namespace Cybersource.Services
             return sendResponse;
         }
 
-        public async Task<SendResponse> SendProxyRequest(HttpMethod method, string endpoint, string jsonSerializedData, string proxyUrl, string proxyTokenUrl)
+        public async Task<SendResponse> SendProxyRequest(HttpMethod method, string endpoint, string jsonSerializedData, string proxyUrl, string proxyTokenUrl, MerchantSettings merchantSettings)
         {
             SendResponse sendResponse = null;
 
             try
             {
-                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
                 string urlBase = CybersourceConstants.ProductionApiEndpoint;
                 if (!merchantSettings.IsLive)
                 {
@@ -464,7 +461,7 @@ namespace Cybersource.Services
         }
 
         #region Payments
-        public async Task<PaymentsResponse> ProcessPayment(Payments payments, string proxyUrl, string proxyTokensUrl)
+        public async Task<PaymentsResponse> ProcessPayment(Payments payments, string proxyUrl, string proxyTokensUrl, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
             try
@@ -474,11 +471,11 @@ namespace Cybersource.Services
                 SendResponse response = null;
                 if (string.IsNullOrEmpty(proxyUrl))
                 {
-                    response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                    response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 }
                 else
                 {
-                    response = await this.SendProxyRequest(HttpMethod.Post, endpoint, json, proxyUrl, proxyTokensUrl);
+                    response = await this.SendProxyRequest(HttpMethod.Post, endpoint, json, proxyUrl, proxyTokensUrl, merchantSettings);
                 }
                 
                 if (response != null)
@@ -517,7 +514,7 @@ namespace Cybersource.Services
             return paymentsResponse;
         }
 
-        public async Task<PaymentsResponse> ProcessReversal(Payments payments, string paymentId)
+        public async Task<PaymentsResponse> ProcessReversal(Payments payments, string paymentId, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
 
@@ -525,7 +522,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(payments);
                 string endpoint = $"{CybersourceConstants.PAYMENTS}payments/{paymentId}/reversals";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 if (response != null)
                 {
                     paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -545,7 +542,7 @@ namespace Cybersource.Services
             return paymentsResponse;
         }
 
-        public async Task<PaymentsResponse> ProcessCapture(Payments payments, string paymentId)
+        public async Task<PaymentsResponse> ProcessCapture(Payments payments, string paymentId, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
 
@@ -553,7 +550,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(payments);
                 string endpoint = $"{CybersourceConstants.PAYMENTS}payments/{paymentId}/captures";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 if (response != null)
                 {
                     paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -574,7 +571,7 @@ namespace Cybersource.Services
         }
 
         /// Refund a Payment API is only used, if you have requested Authorization and Capture together
-        public async Task<PaymentsResponse> RefundPayment(Payments payments, string paymentId)
+        public async Task<PaymentsResponse> RefundPayment(Payments payments, string paymentId, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
 
@@ -582,7 +579,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(payments);
                 string endpoint = $"{CybersourceConstants.PAYMENTS}payments/{paymentId}/refunds";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 if (response != null)
                 {
                     paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -603,7 +600,7 @@ namespace Cybersource.Services
         }
 
         /// Refund a capture API is only used, if you have requested Capture independenlty
-        public async Task<PaymentsResponse> RefundCapture(Payments payments, string captureId)
+        public async Task<PaymentsResponse> RefundCapture(Payments payments, string captureId, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
 
@@ -611,7 +608,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(payments);
                 string endpoint = $"{CybersourceConstants.PAYMENTS}captures/{captureId}/refunds";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 if (response != null)
                 {
                     paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -631,7 +628,7 @@ namespace Cybersource.Services
             return paymentsResponse;
         }
 
-        public async Task<PaymentsResponse> ProcessCredit(Payments payments)
+        public async Task<PaymentsResponse> ProcessCredit(Payments payments, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
 
@@ -639,7 +636,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(payments);
                 string endpoint = $"{CybersourceConstants.PAYMENTS}credits";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 if (response != null)
                 {
                     paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -660,7 +657,7 @@ namespace Cybersource.Services
         #endregion
 
         #region Risk Management
-        public async Task<PaymentsResponse> CreateDecisionManager(Payments payments)
+        public async Task<PaymentsResponse> CreateDecisionManager(Payments payments, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
 
@@ -668,7 +665,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(payments);
                 string endpoint = $"{CybersourceConstants.RISK}decisions";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 if (response != null)
                 {
                     paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -689,12 +686,12 @@ namespace Cybersource.Services
         #endregion
 
         #region Payer Authentication
-        public async Task<PaymentsResponse> SetupPayerAuth(Payments payments, string proxyUrl, string proxyTokensUrl)
+        public async Task<PaymentsResponse> SetupPayerAuth(Payments payments, string proxyUrl, string proxyTokensUrl, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
             string json = JsonConvert.SerializeObject(payments);
             string endpoint = $"{CybersourceConstants.RISK}authentication-setups";
-            SendResponse response = await this.SendProxyRequest(HttpMethod.Post, endpoint, json, proxyUrl, proxyTokensUrl);
+            SendResponse response = await this.SendProxyRequest(HttpMethod.Post, endpoint, json, proxyUrl, proxyTokensUrl, merchantSettings);
             if (response.Success)
             {
                 paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -703,12 +700,12 @@ namespace Cybersource.Services
             return paymentsResponse;
         }
 
-        public async Task<PaymentsResponse> CheckPayerAuthEnrollment(Payments payments, string proxyUrl, string proxyTokensUrl)
+        public async Task<PaymentsResponse> CheckPayerAuthEnrollment(Payments payments, string proxyUrl, string proxyTokensUrl, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
             string json = JsonConvert.SerializeObject(payments);
             string endpoint = $"{CybersourceConstants.RISK}authentications";
-            SendResponse response = await this.SendProxyRequest(HttpMethod.Post, endpoint, json, proxyUrl, proxyTokensUrl);
+            SendResponse response = await this.SendProxyRequest(HttpMethod.Post, endpoint, json, proxyUrl, proxyTokensUrl, merchantSettings);
             if (response.Success)
             {
                 paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -717,12 +714,12 @@ namespace Cybersource.Services
             return paymentsResponse;
         }
 
-        public async Task<PaymentsResponse> ValidateAuthenticationResults(Payments payments, string proxyUrl, string proxyTokensUrl)
+        public async Task<PaymentsResponse> ValidateAuthenticationResults(Payments payments, string proxyUrl, string proxyTokensUrl, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
             string json = JsonConvert.SerializeObject(payments);
             string endpoint = $"{CybersourceConstants.RISK}authentication-results";
-            SendResponse response = await this.SendProxyRequest(HttpMethod.Post, endpoint, json, proxyUrl, proxyTokensUrl);
+            SendResponse response = await this.SendProxyRequest(HttpMethod.Post, endpoint, json, proxyUrl, proxyTokensUrl, merchantSettings);
             if (response.Success)
             {
                 paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -733,7 +730,7 @@ namespace Cybersource.Services
         #endregion
 
         #region Tax
-        public async Task<PaymentsResponse> CalculateTaxes(Payments payments)
+        public async Task<PaymentsResponse> CalculateTaxes(Payments payments, MerchantSettings merchantSettings)
         {
             PaymentsResponse paymentsResponse = null;
 
@@ -741,7 +738,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(payments);
                 string endpoint = $"{CybersourceConstants.TAX}tax";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 if (response != null)
                 {
                     paymentsResponse = JsonConvert.DeserializeObject<PaymentsResponse>(response.Message);
@@ -779,10 +776,10 @@ namespace Cybersource.Services
 
             try
             {
-                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
+                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings(); // TODO: Get override settings
                 string organizationId = merchantSettings.MerchantId;
                 string endpoint = $"{CybersourceConstants.REPORTING}conversion-details?startTime={startTime}&endTime={endTime}&organizationId={organizationId}&";
-                SendResponse response = await this.SendReportRequest(HttpMethod.Get, endpoint, null);
+                SendResponse response = await this.SendReportRequest(HttpMethod.Get, endpoint, null, merchantSettings);
                 if (response != null)
                 {
                     if (response.Success)
@@ -816,7 +813,7 @@ namespace Cybersource.Services
         /// <param name="dtStartTime"></param>
         /// <param name="dtEndTime"></param>
         /// <returns></returns>
-        public async Task<string> NotificationOfChangesReport(DateTime dtStartTime, DateTime dtEndTime)
+        public async Task<string> NotificationOfChangesReport(DateTime dtStartTime, DateTime dtEndTime, MerchantSettings merchantSettings)
         {
             string retval = string.Empty;
             string startTime = dtStartTime.ToString("yyyy-MM-ddTHH:mm:ss.sssZ");
@@ -825,7 +822,7 @@ namespace Cybersource.Services
 
             try
             {
-                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null);
+                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null, merchantSettings);
                 if (response != null)
                 {
                     retval = $"[{response.StatusCode}] {response.Message}";
@@ -858,10 +855,10 @@ namespace Cybersource.Services
 
             try
             {
-                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
+                MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings(); // TODO: Get override settings
                 string organizationId = merchantSettings.MerchantId;
                 string endpoint = $"{CybersourceConstants.REPORTING}report-downloads?reportDate={reportDate}&organizationId={organizationId}&reportName={reportName}";
-                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null);
+                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null, merchantSettings);
                 if (response != null)
                 {
                     retval = $"[{response.StatusCode}] {response.Message}";
@@ -888,7 +885,7 @@ namespace Cybersource.Services
         /// <param name="dtStartTime"></param>
         /// <param name="dtEndTime"></param>
         /// <returns></returns>
-        public async Task<string> RetrieveAvailableReports(DateTime dtStartTime, DateTime dtEndTime)
+        public async Task<string> RetrieveAvailableReports(DateTime dtStartTime, DateTime dtEndTime, MerchantSettings merchantSettings)
         {
             string retval = string.Empty;
             string startTime = dtStartTime.ToString("yyyy-MM-ddTHH:mm:ss.sssZ");
@@ -897,7 +894,7 @@ namespace Cybersource.Services
             try
             {
                 string endpoint = $"{CybersourceConstants.REPORTING}reports?startTime={startTime}&endTime={endTime}&timeQueryType=executedTime";
-                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null);
+                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null, merchantSettings);
                 if (response != null)
                 {
                     retval = $"[{response.StatusCode}] {response.Message}";
@@ -917,7 +914,7 @@ namespace Cybersource.Services
             return retval;
         }
 
-        public async Task<string> GetPurchaseAndRefundDetails(DateTime dtStartTime, DateTime dtEndTime)
+        public async Task<string> GetPurchaseAndRefundDetails(DateTime dtStartTime, DateTime dtEndTime, MerchantSettings merchantSettings)
         {
             string retval = string.Empty;
             string startTime = dtStartTime.ToString("yyyy-MM-ddTHH:mm:ss.sssZ");
@@ -926,7 +923,7 @@ namespace Cybersource.Services
             try
             {
                 string endpoint = $"{CybersourceConstants.REPORTING}purchase-refund-details?startTime={startTime}&endTime={endTime}";
-                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null);
+                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null, merchantSettings);
                 if (response != null)
                 {
                     retval = $"[{response.StatusCode}] {response.Message}";
@@ -947,14 +944,14 @@ namespace Cybersource.Services
             return retval;
         }
 
-        public async Task<RetrieveTransaction> RetrieveTransaction(string transactionId)
+        public async Task<RetrieveTransaction> RetrieveTransaction(string transactionId, MerchantSettings merchantSettings)
         {
             RetrieveTransaction retrieveTransaction = null;
 
             try
             {
                 string endpoint = $"{CybersourceConstants.TRANSACTIONS}transactions/{transactionId}";
-                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null);
+                SendResponse response = await this.SendRequest(HttpMethod.Get, endpoint, null, merchantSettings);
                 if (response != null)
                 {
                     _context.Vtex.Logger.Debug("RetrieveTransaction", null, response.Message);
@@ -974,7 +971,7 @@ namespace Cybersource.Services
             return retrieveTransaction;
         }
 
-        public async Task<SearchResponse> CreateSearchRequest(CreateSearchRequest createSearchRequest)
+        public async Task<SearchResponse> CreateSearchRequest(CreateSearchRequest createSearchRequest, MerchantSettings merchantSettings)
         {
             SearchResponse searchResponse = null;
 
@@ -982,7 +979,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(createSearchRequest);
                 string endpoint = $"{CybersourceConstants.TRANSACTIONS}searches";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 if (response != null)
                 {
                     searchResponse = JsonConvert.DeserializeObject<SearchResponse>(response.Message);
@@ -1002,7 +999,7 @@ namespace Cybersource.Services
         }
         #endregion Reporting
 
-        public async Task<CybersourceBinLookupResponse> BinLookup(string cardNumber)
+        public async Task<CybersourceBinLookupResponse> BinLookup(string cardNumber, MerchantSettings merchantSettings)
         {
             CybersourceBinLookupResponse cybersourceBinLookupResponse = null;
             CybersourceBinLookupRequest cybersourceBinLookupRequest = new CybersourceBinLookupRequest
@@ -1020,7 +1017,7 @@ namespace Cybersource.Services
             {
                 string json = JsonConvert.SerializeObject(cybersourceBinLookupRequest);
                 string endpoint = $"{CybersourceConstants.BIN}binlookup";
-                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json);
+                SendResponse response = await this.SendRequest(HttpMethod.Post, endpoint, json, merchantSettings);
                 _context.Vtex.Logger.Debug("BinLookup", null, null, new[] { ("Bin", cardNumber), ("request", json), ("response", JsonConvert.SerializeObject(response)) });
                 if (response != null)
                 {

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -947,7 +947,11 @@ namespace Cybersource.Services
 
                 string merchantTaxId = string.Empty;
                 bool doCapture = false;
-                (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, paymentData.CreatePaymentRequest.MerchantSettings, merchantName);
+                if (paymentData != null && paymentData.CreatePaymentRequest != null && paymentData.CreatePaymentRequest.MerchantSettings != null)
+                {
+                    (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, paymentData.CreatePaymentRequest.MerchantSettings, merchantName);
+                }
+
                 if (!string.IsNullOrEmpty(merchantSettings.OrderSuffix))
                 {
                     orderSuffix = merchantSettings.OrderSuffix.Trim();

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -1412,7 +1412,7 @@ namespace Cybersource.Services
                         sendAntifraudDataResponse.Message = paymentsResponse.ErrorInformation.Message;
                     }
 
-                    if (sendAntifraudDataRequest != null)
+                    if (sendAntifraudDataResponse != null)
                     {
                         await _cybersourceRepository.SaveAntifraudData(sendAntifraudDataRequest.Id, sendAntifraudDataResponse);
                     }

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -939,7 +939,12 @@ namespace Cybersource.Services
 
                 string orderSuffix = string.Empty;
                 MerchantSettings merchantSettings = await _cybersourceRepository.GetMerchantSettings();
-                string merchantName = paymentData.CreatePaymentRequest.MerchantName;
+                string merchantName = string.Empty;
+                if (paymentData != null && paymentData.CreatePaymentResponse != null && !string.IsNullOrEmpty(paymentData.CreatePaymentRequest.MerchantName))
+                {
+                    merchantName = paymentData.CreatePaymentRequest.MerchantName;
+                }
+
                 string merchantTaxId = string.Empty;
                 bool doCapture = false;
                 (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, paymentData.CreatePaymentRequest.MerchantSettings, merchantName);
@@ -2681,6 +2686,7 @@ namespace Cybersource.Services
                         case "PARTIAL_AUTHORIZED":
                         case "AUTHENTICATION_SUCCESSFUL":
                         case "SOK":
+                        case "ACCEPTED":
                             if (isPayerAuth)
                             {
                                 if (!string.IsNullOrEmpty(paymentsResponse.ConsumerAuthenticationInformation.VeresEnrolled) &&

--- a/dotnet/Services/ICybersourceApi.cs
+++ b/dotnet/Services/ICybersourceApi.cs
@@ -6,27 +6,27 @@ namespace Cybersource.Services
 {
     public interface ICybersourceApi
     {
-        Task<PaymentsResponse> ProcessPayment(Payments payments, string proxyUrl, string proxyTokensUrl);
-        Task<PaymentsResponse> ProcessReversal(Payments payments, string paymentId);
-        Task<PaymentsResponse> ProcessCapture(Payments payments, string paymentId);
-        Task<PaymentsResponse> RefundPayment(Payments payments, string paymentId);
-        Task<PaymentsResponse> RefundCapture(Payments payments, string captureId);
-        Task<PaymentsResponse> ProcessCredit(Payments payments);
+        Task<PaymentsResponse> ProcessPayment(Payments payments, string proxyUrl, string proxyTokensUrl, MerchantSettings merchantSettings);
+        Task<PaymentsResponse> ProcessReversal(Payments payments, string paymentId, MerchantSettings merchantSettings);
+        Task<PaymentsResponse> ProcessCapture(Payments payments, string paymentId, MerchantSettings merchantSettings);
+        Task<PaymentsResponse> RefundPayment(Payments payments, string paymentId, MerchantSettings merchantSettings);
+        Task<PaymentsResponse> RefundCapture(Payments payments, string captureId, MerchantSettings merchantSettings);
+        Task<PaymentsResponse> ProcessCredit(Payments payments, MerchantSettings merchantSettings);
 
-        Task<PaymentsResponse> CreateDecisionManager(Payments payments);
+        Task<PaymentsResponse> CreateDecisionManager(Payments payments, MerchantSettings merchantSettings);
 
-        Task<PaymentsResponse> CalculateTaxes(Payments payments);
+        Task<PaymentsResponse> CalculateTaxes(Payments payments, MerchantSettings merchantSettings);
 
         Task<ConversionReportResponse> ConversionDetailReport(DateTime dtStartTime, DateTime dtEndTime);
-        Task<string> RetrieveAvailableReports(DateTime dtStartTime, DateTime dtEndTime);
-        Task<string> GetPurchaseAndRefundDetails(DateTime dtStartTime, DateTime dtEndTime);
-        Task<RetrieveTransaction> RetrieveTransaction(string transactionId);
-        Task<SearchResponse> CreateSearchRequest(CreateSearchRequest createSearchRequest);
+        Task<string> RetrieveAvailableReports(DateTime dtStartTime, DateTime dtEndTime, MerchantSettings merchantSettings);
+        Task<string> GetPurchaseAndRefundDetails(DateTime dtStartTime, DateTime dtEndTime, MerchantSettings merchantSettings);
+        Task<RetrieveTransaction> RetrieveTransaction(string transactionId, MerchantSettings merchantSettings);
+        Task<SearchResponse> CreateSearchRequest(CreateSearchRequest createSearchRequest, MerchantSettings merchantSettings);
 
-        Task<PaymentsResponse> SetupPayerAuth(Payments payments, string proxyUrl, string proxyTokensUrl);
-        Task<PaymentsResponse> CheckPayerAuthEnrollment(Payments payments, string proxyUrl, string proxyTokensUrl);
-        Task<PaymentsResponse> ValidateAuthenticationResults(Payments payments, string proxyUrl, string proxyTokensUrl);
+        Task<PaymentsResponse> SetupPayerAuth(Payments payments, string proxyUrl, string proxyTokensUrl, MerchantSettings merchantSettings);
+        Task<PaymentsResponse> CheckPayerAuthEnrollment(Payments payments, string proxyUrl, string proxyTokensUrl, MerchantSettings merchantSettings);
+        Task<PaymentsResponse> ValidateAuthenticationResults(Payments payments, string proxyUrl, string proxyTokensUrl, MerchantSettings merchantSettings);
 
-        Task<CybersourceBinLookupResponse> BinLookup(string cardNumber);
+        Task<CybersourceBinLookupResponse> BinLookup(string cardNumber, MerchantSettings merchantSettings);
     }
 }

--- a/dotnet/Services/ICybersourcePaymentService.cs
+++ b/dotnet/Services/ICybersourcePaymentService.cs
@@ -7,7 +7,7 @@ namespace Cybersource.Services
 {
     public interface ICybersourcePaymentService
     {
-        Task<(CreatePaymentResponse, PaymentsResponse)> CreatePayment(CreatePaymentRequest createPaymentRequest, string authenticationTransactionId = null, ConsumerAuthenticationInformation consumerAuthenticationInformation = null);
+        Task<(CreatePaymentResponse, PaymentsResponse)> CreatePayment(CreatePaymentRequest createPaymentRequest, string authenticationTransactionId = null, ConsumerAuthenticationInformation consumerAuthenticationInformation = null, MerchantSettings merchantSettings = null);
         Task<CancelPaymentResponse> CancelPayment(CancelPaymentRequest cancelPaymentRequest);
         Task<CapturePaymentResponse> CapturePayment(CapturePaymentRequest capturePaymentRequest);
         Task<RefundPaymentResponse> RefundPayment(RefundPaymentRequest refundPaymentRequest);

--- a/dotnet/Services/VtexApiService.cs
+++ b/dotnet/Services/VtexApiService.cs
@@ -705,7 +705,7 @@ namespace Cybersource.Services
 
                     cyberTaxRequest.orderInformation.lineItems.Add(lineItemShipping);
 
-                    PaymentsResponse taxResponse = await _cybersourceApi.CalculateTaxes(cyberTaxRequest);
+                    PaymentsResponse taxResponse = await _cybersourceApi.CalculateTaxes(cyberTaxRequest, merchantSettings);
                     if (taxResponse != null)
                     {
                         if (taxResponse.Status.Equals("COMPLETED"))
@@ -1014,7 +1014,7 @@ namespace Cybersource.Services
 
                         cyberTaxRequest.orderInformation.lineItems.Add(lineItemShipping);
 
-                        PaymentsResponse taxResponse = await _cybersourceApi.CalculateTaxes(cyberTaxRequest);
+                        PaymentsResponse taxResponse = await _cybersourceApi.CalculateTaxes(cyberTaxRequest, merchantSettings);
                         if (taxResponse != null)
                         {
                             if (taxResponse.Status.Equals("COMPLETED"))


### PR DESCRIPTION
Credentials set on the Admin page should be overridden by credentials set on the Gateway.