### PR TITLE
Attempted fix for double billing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- If Auth & Bill is enabled, set Timeout flag by default to force a check for previous captures.
+
 ## [1.18.2] - 2023-06-08
 
 ### Fixed

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -606,6 +606,7 @@ namespace Cybersource.Services
                                 SearchResponse searchResponse = await this.SearchTransaction($"{referenceNumber}{orderSuffix}", merchantSettings);
                                 if (searchResponse != null)
                                 {
+                                    createPaymentResponse = new CreatePaymentResponse();
                                     createPaymentResponse.PaymentId = createPaymentRequest.PaymentId;
                                     createPaymentResponse.Status = CybersourceConstants.VtexAuthStatus.Denied;
                                     foreach (var transactionSummary in searchResponse.Embedded.TransactionSummaries.Where(transactionSummary => transactionSummary.ApplicationInformation.Applications.Exists(ai => ai.Name.Equals(CybersourceConstants.Applications.Capture) && ai.ReasonCode.Equals("100"))))


### PR DESCRIPTION
If Auth & Bill is enabled, set Timeout flag by default to force a check for previous captures on subsequent requests.