### PR TITLE
Remove parenthesis from signature header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Remove parenthesis from signature header to comply with Cybersource security change 
+
 ## [1.19.3] - 2023-12-20
 
 ### Fixed

--- a/dotnet/Services/CybersourceApi.cs
+++ b/dotnet/Services/CybersourceApi.cs
@@ -1056,8 +1056,8 @@ namespace Cybersource.Services
             var signatureString = new StringBuilder();
             var signatureHeaderValue = new StringBuilder();
             string headersString = string.Empty;
-            const string getOrDeleteHeaders = "host date (request-target) v-c-merchant-id";
-            const string postOrPutHeaders = "host date (request-target) digest v-c-merchant-id";
+            const string getOrDeleteHeaders = "host date request-target v-c-merchant-id";
+            const string postOrPutHeaders = "host date request-target digest v-c-merchant-id";
             if (string.IsNullOrEmpty(digest))
             {
                 headersString = getOrDeleteHeaders;
@@ -1076,7 +1076,7 @@ namespace Cybersource.Services
             signatureString.Append(": ");
             signatureString.Append(gmtDateTime);
             signatureString.Append('\n');
-            signatureString.Append("(request-target)");
+            signatureString.Append("request-target");
             signatureString.Append(": ");
             signatureString.Append(requestTarget);
             signatureString.Append('\n');
@@ -1112,8 +1112,8 @@ namespace Cybersource.Services
             var signatureString = new StringBuilder();
             var signatureHeaderValue = new StringBuilder();
             string headersString = string.Empty;
-            const string getOrDeleteHeaders = "host date (request-target) v-c-merchant-id";
-            const string postOrPutHeaders = "host date (request-target) digest v-c-merchant-id";
+            const string getOrDeleteHeaders = "host date request-target v-c-merchant-id";
+            const string postOrPutHeaders = "host date request-target digest v-c-merchant-id";
             if (string.IsNullOrEmpty(digest))
             {
                 headersString = getOrDeleteHeaders;
@@ -1132,7 +1132,7 @@ namespace Cybersource.Services
             signatureString.Append(": ");
             signatureString.Append(gmtDateTime);
             signatureString.Append('\n');
-            signatureString.Append("(request-target)");
+            signatureString.Append("request-target");
             signatureString.Append(": ");
             signatureString.Append(requestTarget);
             signatureString.Append('\n');
@@ -1190,7 +1190,7 @@ namespace Cybersource.Services
         {
             var signatureString = new StringBuilder();
             var signatureHeaderValue = new StringBuilder();
-            string headersString = "host v-c-date (request-target) v-c-merchant-id";
+            string headersString = "host v-c-date request-target v-c-merchant-id";
 
             signatureString.Append('\n');
             signatureString.Append("host");
@@ -1201,7 +1201,7 @@ namespace Cybersource.Services
             signatureString.Append(": ");
             signatureString.Append(gmtDateTime);
             signatureString.Append('\n');
-            signatureString.Append("(request-target)");
+            signatureString.Append("request-target");
             signatureString.Append(": ");
             signatureString.Append(requestTarget);
             signatureString.Append('\n');


### PR DESCRIPTION
Remove parenthesis from signature header to comply with Cybersource security change
https://vtexhelp.zendesk.com/agent/tickets/974344
https://community.developer.cybersource.com/t5/cybersource-Developer-Blog/REST-API-Http-Signature-Authentication-Critical-Security-Update/ba-p/87319