### PR TITLE
If merchant settings are not loaded from storage, get from request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- If merchant settings are not loaded from storage, get from request
+
 ## [1.20.0] - 2024-01-31
 
 ### Changed

--- a/dotnet/Models/CancelPaymentRequest.cs
+++ b/dotnet/Models/CancelPaymentRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Cybersource.Models
 {   
@@ -12,5 +13,8 @@ namespace Cybersource.Models
 
         [JsonProperty("authorizationId")]
         public string AuthorizationId { get; set; }
+
+        [JsonProperty("merchantSettings")]
+        public List<MerchantSetting> MerchantSettings { get; set; }
     }
 }

--- a/dotnet/Models/CapturePaymentRequest.cs
+++ b/dotnet/Models/CapturePaymentRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Cybersource.Models
 {
@@ -18,5 +19,8 @@ namespace Cybersource.Models
 
         [JsonProperty("authorizationId")]
         public string AuthorizationId { get; set; }
+
+        [JsonProperty("merchantSettings")]
+        public List<MerchantSetting> MerchantSettings { get; set; }
     }
 }

--- a/dotnet/Models/RefundPaymentRequest.cs
+++ b/dotnet/Models/RefundPaymentRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Cybersource.Models
 {
@@ -18,5 +19,8 @@ namespace Cybersource.Models
 
         [JsonProperty("requestId")]
         public string RequestId { get; set; }
+
+        [JsonProperty("merchantSettings")]
+        public List<MerchantSetting> MerchantSettings { get; set; }
     }
 }

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -860,7 +860,15 @@ namespace Cybersource.Services
                 string merchantName = paymentData.CreatePaymentRequest.MerchantName;
                 string merchantTaxId = string.Empty;
                 bool doCapture = false;
-                (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, paymentData.CreatePaymentRequest.MerchantSettings, merchantName);
+                if (paymentData != null && paymentData.CreatePaymentRequest != null && paymentData.CreatePaymentRequest.MerchantSettings != null)
+                {
+                    (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, paymentData.CreatePaymentRequest.MerchantSettings, merchantName);
+                }
+                else if (cancelPaymentRequest.MerchantSettings != null)
+                {
+                    (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, cancelPaymentRequest.MerchantSettings, merchantName);
+                }
+
                 if (!string.IsNullOrEmpty(merchantSettings.OrderSuffix))
                 {
                     orderSuffix = merchantSettings.OrderSuffix.Trim();
@@ -991,6 +999,10 @@ namespace Cybersource.Services
                 if (paymentData != null && paymentData.CreatePaymentRequest != null && paymentData.CreatePaymentRequest.MerchantSettings != null)
                 {
                     (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, paymentData.CreatePaymentRequest.MerchantSettings, merchantName);
+                }
+                else if(capturePaymentRequest.MerchantSettings != null)
+                {
+                    (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, capturePaymentRequest.MerchantSettings, merchantName);
                 }
 
                 if (!string.IsNullOrEmpty(merchantSettings.OrderSuffix))
@@ -1238,7 +1250,15 @@ namespace Cybersource.Services
                 string merchantName = paymentData.CreatePaymentRequest.MerchantName;
                 string merchantTaxId = string.Empty;
                 bool doCapture = false;
-                (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, paymentData.CreatePaymentRequest.MerchantSettings, merchantName);
+                if (paymentData != null && paymentData.CreatePaymentRequest != null && paymentData.CreatePaymentRequest.MerchantSettings != null)
+                {
+                    (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, paymentData.CreatePaymentRequest.MerchantSettings, merchantName);
+                }
+                else if (refundPaymentRequest.MerchantSettings != null)
+                {
+                    (merchantSettings, merchantName, merchantTaxId, doCapture) = await this.ParseGatewaySettings(merchantSettings, refundPaymentRequest.MerchantSettings, merchantName);
+                }
+
                 if (!string.IsNullOrEmpty(merchantSettings.OrderSuffix))
                 {
                     orderSuffix = merchantSettings.OrderSuffix.Trim();


### PR DESCRIPTION
If the merchant settings, including the account override settings are not loaded from storage, use the values from the request.