### PR TITLE
allow two digit country codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Accept two digit country codes
+
 ## [1.22.0] - 2024-06-03
 
 ### Fixed

--- a/dotnet/Services/CybersourcePaymentService.cs
+++ b/dotnet/Services/CybersourcePaymentService.cs
@@ -2259,7 +2259,14 @@ namespace Cybersource.Services
             string retval = string.Empty;
             if (!string.IsNullOrEmpty(country))
             {
-                retval = CybersourceConstants.CountryCodesMapping[country];
+                if (country.Length == 2)
+                {
+                    retval = country;
+                }
+                else if (country.Length == 3)
+                {
+                    retval = CybersourceConstants.CountryCodesMapping[country];
+                }
             }
 
             return retval;


### PR DESCRIPTION
If country is three characters, convert to two.  If two, assume the code is correct.  If not 2 or 3, return empty string