### PR TITLE
Added check for Decison Manager order updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added check for Decison Manager order updates
+
 ## [1.23.0] - 2024-07-12
 
 ### Fixed

--- a/dotnet/Controlers/RoutesController.cs
+++ b/dotnet/Controlers/RoutesController.cs
@@ -925,10 +925,10 @@
             return Json(await _cybersourcePaymentService.GetPurchaseAndRefundDetails(DateTime.Now.AddDays(-7), DateTime.Now.AddDays(0)));
         }
 
-        public async Task<IActionResult> ProcessConversions()
+        public async Task<IActionResult> ProcessConversions(int days)
         {
             Response.Headers.Add("Cache-Control", "no-cache");
-            return Json(await _vtexApiService.ProcessConversions());
+            return Json(await _vtexApiService.ProcessConversions(days));
         }
 
         public async Task<IActionResult> DecisionManagerNotify()

--- a/dotnet/Services/IVtexApiService.cs
+++ b/dotnet/Services/IVtexApiService.cs
@@ -19,7 +19,7 @@ namespace Cybersource.Services
         Task<VtexTaxResponse> GetFallbackTaxes(VtexTaxRequest taxRequest);
 
         Task<SendResponse> PostCallbackResponse(string callbackUrl, CreatePaymentResponse createPaymentResponse);
-        Task<string> ProcessConversions();
+        Task<string> ProcessConversions(int days);
         Task<string> UpdateOrderStatus(string merchantReferenceNumber, string newDecision, string comments);
         Task<VtexOrder> GetOrderInformation(string orderId, bool fromOMS = false);
         Task<VtexOrder[]> GetOrderGroup(string orderId);

--- a/dotnet/Services/VtexApiService.cs
+++ b/dotnet/Services/VtexApiService.cs
@@ -898,6 +898,9 @@ namespace Cybersource.Services
                             case CybersourceConstants.VtexOrderStatus.Invoiced:
                                 success = await this.ProcessInvoice(allStatesNotification.OrderId);
                                 break;
+                            case CybersourceConstants.VtexOrderStatus.ApprovePayment:
+                                _ = await this.ProcessConversions();
+                                break;
                         }
 
                         break;

--- a/dotnet/Services/VtexApiService.cs
+++ b/dotnet/Services/VtexApiService.cs
@@ -899,7 +899,7 @@ namespace Cybersource.Services
                                 success = await this.ProcessInvoice(allStatesNotification.OrderId);
                                 break;
                             case CybersourceConstants.VtexOrderStatus.ApprovePayment:
-                                _ = await this.ProcessConversions();
+                                _ = await this.ProcessConversions(2);
                                 break;
                         }
 
@@ -1049,14 +1049,14 @@ namespace Cybersource.Services
             return success;
         }
 
-        public async Task<string> ProcessConversions()
+        public async Task<string> ProcessConversions(int days)
         {
             string results = string.Empty;
 
             try
             {
                 StringBuilder sb = new StringBuilder();
-                DateTime dtStartTime = DateTime.Now.AddDays(-1);
+                DateTime dtStartTime = DateTime.Now.AddDays(-days);
                 DateTime dtEndTime = DateTime.Now;
                 ConversionReportResponse conversionReport = await _cybersourceApi.ConversionDetailReport(dtStartTime, dtEndTime);
                 if (conversionReport != null)

--- a/dotnet/service.json
+++ b/dotnet/service.json
@@ -101,7 +101,7 @@
       "public": true
     },
     "processConversions": {
-      "path": "/cybersource/payment-provider/process-conversions",
+      "path": "/cybersource/payment-provider/process-conversions/:days",
       "public": true
     },
     "decisionManagerNotify": {


### PR DESCRIPTION
When a new order is placed, use that event as a trigger to pull a report from Cybersource on any order status conversions and update the status in VTEX