### PR TITLE
Add log for elapsed time processing a payment capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added payment capture method elapsed time logs
+
 ## [1.26.0] - 2024-08-07
 
 ### Added


### PR DESCRIPTION
Added one stopwatcher to each async method inside the payment capture method, and then logged the total elapsed time and the elapsed time for each step.